### PR TITLE
Humane names

### DIFF
--- a/moneybot/market/adapters/__init__.py
+++ b/moneybot/market/adapters/__init__.py
@@ -64,25 +64,25 @@ class MarketAdapter(metaclass=ABCMeta):
 
         # Check that we have enough to sell
         try:
-            held_amount = self.market_state.balances[proposed.from_coin]
+            held_amount = self.market_state.balances[proposed.sell_coin]
         except KeyError:
             logger.warning(
-                f"Trying to sel {proposed.from_coin}, but none is held."
+                f"Trying to sel {proposed.sell_coin}, but none is held."
             )
             return None
 
         if held_amount == 0:
             logger.warning(
-                f"Trying to sell {proposed.from_coin}, but none is held."
+                f"Trying to sell {proposed.sell_coin}, but none is held."
             )
             return None
 
-        if proposed.bid_amount > held_amount:
+        if proposed.sell_amount > held_amount:
             logger.warning(
-                f"Holding {held_amount} {proposed.from_coin}, but trying to sell more than is held, {proposed.bid_amount}."
+                f"Holding {held_amount} {proposed.sell_coin}, but trying to sell more than is held, {proposed.sell_amount}."
                 "Simply selling maximum amount."
             )
-            proposed.set_bid_amount(held_amount, self.market_state)
+            proposed.set_sell_amount(held_amount, self.market_state)
             return proposed
 
         # Check that proposed bid has a price:
@@ -93,7 +93,7 @@ class MarketAdapter(metaclass=ABCMeta):
             return None
 
         # Check that we are trading a positive amount for a positive amount
-        if proposed.bid_amount < 0 or proposed.ask_amount < 0:
+        if proposed.sell_amount < 0 or proposed.buy_amount < 0:
             logger.warning(
                 'Filtering out proposed trade (bid or ask amount < 0): '
                 f'{proposed}.'
@@ -102,8 +102,8 @@ class MarketAdapter(metaclass=ABCMeta):
 
         # Check that the proposed trade exceeds minimum fiat trade amount.
         if (
-            (proposed.from_coin == proposed.fiat and proposed.bid_amount < 0.0001) or
-            (proposed.to_coin == proposed.fiat and proposed.ask_amount < 0.0001)
+            (proposed.sell_coin == proposed.fiat and proposed.sell_amount < 0.0001) or
+            (proposed.buy_coin == proposed.fiat and proposed.buy_amount < 0.0001)
         ):
             logger.warning(
                 'Filtering out proposed trade (transaction too small): '

--- a/moneybot/market/adapters/live.py
+++ b/moneybot/market/adapters/live.py
@@ -128,8 +128,9 @@ class LiveMarketAdapter(MarketAdapter):
         proposed_trade: ProposedTrade,
         market_state: MarketState,
     ) -> Dict:
-        # if we're trading FROM fiat, that's a "sell"
-        if proposed_trade.sell_coin == market_state.fiat:
+        base_currency = proposed_trade.market_name.split('_')[0]
+        # if we're trading FROM a base currency, that's a "sell"
+        if proposed_trade.sell_coin == base_currency:
             return self._purchase_helper(
                 'buy',
                 proposed_trade.market_name,
@@ -142,8 +143,8 @@ class LiveMarketAdapter(MarketAdapter):
                 self._adjust_up,
             )
 
-        # if we're trading TO fiat, that's a "sell"
-        elif proposed_trade.buy_coin == market_state.fiat:
+        # if we're trading TO the base currency, that's a "sell"
+        elif proposed_trade.buy_coin == base_currency:
             return self._purchase_helper(
                 'sell',
                 proposed_trade.market_name,

--- a/moneybot/market/adapters/live.py
+++ b/moneybot/market/adapters/live.py
@@ -131,7 +131,7 @@ class LiveMarketAdapter(MarketAdapter):
 
         # in the language of poloniex,
         # buying a market's quote currency is a "buy"
-        if proposed_trade.buy_coin == proposed_trade.market_quote_currency():
+        if proposed_trade.buy_coin == proposed_trade.market_quote_currency:
             return self._purchase_helper(
                 'buy',
                 proposed_trade.market_name,
@@ -146,7 +146,7 @@ class LiveMarketAdapter(MarketAdapter):
 
         # in the language of poloniex,
         # buying a market's base currency is a "sell"
-        elif proposed_trade.buy_coin == proposed_trade.market_base_currency():
+        elif proposed_trade.buy_coin == proposed_trade.market_base_currency:
             return self._purchase_helper(
                 'sell',
                 proposed_trade.market_name,

--- a/moneybot/market/adapters/live.py
+++ b/moneybot/market/adapters/live.py
@@ -129,12 +129,12 @@ class LiveMarketAdapter(MarketAdapter):
         market_state: MarketState,
     ) -> Dict:
         # if we're trading FROM fiat, that's a "sell"
-        if proposed_trade.from_coin == market_state.fiat:
+        if proposed_trade.sell_coin == market_state.fiat:
             return self._purchase_helper(
                 'buy',
                 proposed_trade.market_name,
                 proposed_trade.market_price,
-                proposed_trade.ask_amount,
+                proposed_trade.buy_amount,
                 self.polo.buy,
                 # We try to buy low,
                 # But don't always get to,
@@ -143,12 +143,12 @@ class LiveMarketAdapter(MarketAdapter):
             )
 
         # if we're trading TO fiat, that's a "sell"
-        elif proposed_trade.to_coin == market_state.fiat:
+        elif proposed_trade.buy_coin == market_state.fiat:
             return self._purchase_helper(
                 'sell',
                 proposed_trade.market_name,
                 proposed_trade.market_price,
-                proposed_trade.bid_amount,
+                proposed_trade.sell_amount,
                 self.polo.sell,
                 # We try to sell high,
                 # But don't always get to,

--- a/moneybot/market/adapters/live.py
+++ b/moneybot/market/adapters/live.py
@@ -128,9 +128,10 @@ class LiveMarketAdapter(MarketAdapter):
         proposed_trade: ProposedTrade,
         market_state: MarketState,
     ) -> Dict:
-        base_currency = proposed_trade.market_name.split('_')[0]
-        # if we're trading FROM a base currency, that's a "sell"
-        if proposed_trade.sell_coin == base_currency:
+
+        # in the language of poloniex,
+        # buying a market's quote currency is a "buy"
+        if proposed_trade.buy_coin == proposed_trade.market_quote_currency():
             return self._purchase_helper(
                 'buy',
                 proposed_trade.market_name,
@@ -143,8 +144,9 @@ class LiveMarketAdapter(MarketAdapter):
                 self._adjust_up,
             )
 
-        # if we're trading TO the base currency, that's a "sell"
-        elif proposed_trade.buy_coin == base_currency:
+        # in the language of poloniex,
+        # buying a market's base currency is a "sell"
+        elif proposed_trade.buy_coin == proposed_trade.market_base_currency():
             return self._purchase_helper(
                 'sell',
                 proposed_trade.market_name,

--- a/moneybot/market/state.py
+++ b/moneybot/market/state.py
@@ -136,11 +136,11 @@ class MarketState:
         '''
         def simulate(proposed, new_balances):
             # TODO This makes sense as logic, but new_balances is confusing
-            new_balances[proposed.from_coin] -= proposed.bid_amount
-            if proposed.to_coin not in new_balances:
-                new_balances[proposed.to_coin] = 0
-            est_trade_amt = proposed.bid_amount / proposed.price
-            new_balances[proposed.to_coin] += est_trade_amt
+            new_balances[proposed.sell_coin] -= proposed.sell_amount
+            if proposed.buy_coin not in new_balances:
+                new_balances[proposed.buy_coin] = 0
+            est_trade_amt = proposed.sell_amount / proposed.price
+            new_balances[proposed.buy_coin] += est_trade_amt
             return new_balances
         '''
         This method sanity-checks all proposed purchases,

--- a/moneybot/strategy.py
+++ b/moneybot/strategy.py
@@ -51,18 +51,15 @@ class ProposedTrade:
         elif buy_coin == fiat:
             self.market_name = self._get_market_name(fiat, sell_coin)
 
+        # Set the "base" and "quote" currency (strings)
+        self.market_base_currency, self.market_quote_currency = self.market_name.split('_')
+
     def __str__(self) -> str:
         return '{!s} {!s} for {!s} {!s} (price of {!s} {!s}/{!s} on market {!s})'.format(
             self.sell_amount, self.sell_coin,
             self.buy_amount, self.buy_coin,
             self.price, self.sell_coin, self.buy_coin,
             self.market_name)
-
-    def market_base_currency(self):
-        return self.market_name.split('_')[0]
-
-    def market_quote_currency(self):
-        return self.market_name.split('_')[1]
 
     '''
     Private methods
@@ -108,7 +105,7 @@ class ProposedTrade:
         # The base price is always in the base currency,
         # So we will need to figure out if we are trading from,
         # or to, this base currency.
-        if self.buy_coin == self.market_base_currency():
+        if self.buy_coin == self.market_base_currency:
             self.price = 1 / base_price
         else:
             self.price = base_price

--- a/moneybot/strategy.py
+++ b/moneybot/strategy.py
@@ -58,6 +58,12 @@ class ProposedTrade:
             self.price, self.sell_coin, self.buy_coin,
             self.market_name)
 
+    def market_base_currency(self):
+        return self.market_name.split('_')[0]
+
+    def market_quote_currency(self):
+        return self.market_name.split('_')[1]
+
     '''
     Private methods
     '''
@@ -102,8 +108,7 @@ class ProposedTrade:
         # The base price is always in the base currency,
         # So we will need to figure out if we are trading from,
         # or to, this base currency.
-        base_currency = self.market_name.split('_')[0]
-        if self.buy_coin == base_currency:
+        if self.buy_coin == self.market_base_currency():
             self.price = 1 / base_price
         else:
             self.price = base_price

--- a/moneybot/strategy.py
+++ b/moneybot/strategy.py
@@ -98,7 +98,12 @@ class ProposedTrade:
         # So, we keep around a self.market_price to match
         # self.price is always in the quote currency.
         self.market_price = base_price
-        if self.buy_coin == self.fiat:
+        # Now, we find out what price matters for our trade.
+        # The base price is always in the base currency,
+        # So we will need to figure out if we are trading from,
+        # or to, this base currency.
+        base_currency = self.market_name.split('_')[0]
+        if self.buy_coin == base_currency:
             self.price = 1 / base_price
         else:
             self.price = base_price


### PR DESCRIPTION
These three commits make our codebase a little more readable.

1. We replace the terms `from_coin` and `to_coin` with `sell_coin` and `buy_coin`, respectively. We also replace `bid_amount` and `ask_amount` with `sell_amount` and `buy_amount`, respectively. Much more intuitive, and fewer different terms floating around.

2. We get rid of `fiat` in two places, where we can help it. (One fine day, we will have no notion of fiat in our codebase, because the market adapter will simply know which trades are legal. But, that day has not yet come.)