### PR TITLE
Strategy trade proposal refactor

### DIFF
--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -30,6 +30,9 @@ def main(args):
     adapter = LiveMarketAdapter(MarketHistory(), fiat)
 
     fund = Fund(strategy, adapter)
+
+    if args.reset is True:
+        fund.reset()
     fund.run_live()
 
 
@@ -54,7 +57,13 @@ if __name__ == '__main__':
         type=str,
         choices=strategies.keys(),
     )
-    args = parser.parse_args()
 
+    parser.add_argument(
+        '--reset',
+        action='store_true',
+        help='Reset fund (equal values in each coin) before starting to live trade',
+    )
+
+    args = parser.parse_args()
     logging.basicConfig(level=args.log_level)
     main(args)

--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -32,7 +32,9 @@ def main(args):
     fund = Fund(strategy, adapter)
 
     if args.reset is True:
-        fund.reset()
+        confirm = input('Are you sure you want to reset your fund? [y/N] ')
+        if confirm.strip().lower() == 'y':
+            fund.reset()
     fund.run_live()
 
 

--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -31,10 +31,10 @@ def main(args):
 
     fund = Fund(strategy, adapter)
 
-    if args.reset is True:
-        confirm = input('Are you sure you want to reset your fund? [y/N] ')
+    if args.force_rebalance is True:
+        confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
         if confirm.strip().lower() == 'y':
-            fund.reset()
+            fund.rebalance()
     fund.run_live()
 
 
@@ -61,9 +61,9 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '--reset',
+        '--force-rebalance',
         action='store_true',
-        help='Reset fund (equal values in each coin) before starting to live trade',
+        help='Equalize value held in all available coins before starting to live trade',
     )
 
     args = parser.parse_args()

--- a/moneybot/examples/strategies.py
+++ b/moneybot/examples/strategies.py
@@ -23,22 +23,20 @@ class BuyHoldStrategy(Strategy):
 
 class BuffedCoinStrategy(Strategy):
 
+    # HACK HACK HACK HACK HACK
+    magic_number = 1.5  # HACK
+    # HACK HACK HACK HACK HACK
+
     def median(self, est_values: Dict[str, float]) -> float:
         return median(list(est_values.values()))
 
     def is_buffed(
-            self,
-            coin: str,
-            coin_values: Dict[str, float]
+        self,
+        coin: str,
+        coin_values: Dict[str, float]
     ) -> bool:
-        # HACK HACK HACK HACK HACK
-        # HACK magic number HACK
-        # HACK HACK HACK HACK HACK
-        MULTIPLIER = 1.5
         median_value = self.median(coin_values)
-        if coin_values[coin] > (median_value * MULTIPLIER):
-            return True
-        return False
+        return coin_values[coin] > (median_value * type(self).magic_number)
 
     def find_buffed_coins(self, market_state):
         est_values = market_state.estimate_values()

--- a/moneybot/examples/strategies.py
+++ b/moneybot/examples/strategies.py
@@ -15,6 +15,7 @@ class BuyHoldStrategy(Strategy):
         # If we only have BTC,
         if market_state.only_holding(self.fiat):
             # buy some stuff
+            self.has_proposed_initial_trades = True
             return self.initial_proposed_trades(market_state)
 
         # if we hold things other than BTC, hold.
@@ -47,12 +48,12 @@ class BuffedCoinStrategy(Strategy):
         return buffed_coins
 
     def propose_trades(self, market_state, market_history):
-        # First of all, if we only hold fiat,
-        if market_state.only_holding(self.fiat):
+        # If we're just starting up, make initial trades
+        if self.has_proposed_initial_trades is False:
+            self.has_proposed_initial_trades = True
             return self.initial_proposed_trades(market_state)
 
-        # If we do have stuff other than fiat,
-        # see if any of those holdings are buffed
+        # Otherwise, see if any of our holdings are buffed
         buffed_coins = self.find_buffed_coins(market_state)
         # if any of them are,
         if len(buffed_coins):
@@ -128,6 +129,7 @@ class PeakRiderStrategy(BuffedCoinStrategy):
         # First of all, if we only hold fiat,
         if market_state.only_holding(self.fiat):
             # Make initial trades
+            self.has_proposed_initial_trades = True
             return self.initial_proposed_trades(market_state)
         # If we do have stuff other than fiat,
         # see if any of those holdings are buffed

--- a/moneybot/examples/strategies.py
+++ b/moneybot/examples/strategies.py
@@ -41,14 +41,15 @@ class BuffedCoinStrategy(Strategy):
     def find_buffed_coins(self, market_state):
         est_values = market_state.estimate_values()
         buffed_coins = [
-            coin for coin in market_state.held_coins_with_chart_data()
+            coin for coin
+            in market_state.held_coins_with_chart_data()
             if self.is_buffed(coin, est_values)
         ]
         return buffed_coins
 
     def propose_trades(self, market_state, market_history):
-        # If we're just starting up, make initial trades
-        if market_state.only_holding(self.fiat):
+        # If there are coins we don't own, perform a total rebalancing
+        if len(market_state.available_coins_not_held()) > 0:
             return self.propose_trades_for_total_rebalancing(market_state)
 
         # Otherwise, see if any of our holdings are buffed

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -42,9 +42,9 @@ class Fund:
         # MarketHistory stores historical market data
         self.market_history = adapter.market_history
 
-    def reset(self) -> float:
-        """Resetting the fund brings it back to a value-balanced state, i.e.
-        we hold an equal value (measured in fiat) of every coin available to us.
+    def rebalance(self) -> float:
+        """Reset the fund to a value-balanced state, i.e. we hold an equal
+        value (measured in fiat) of every coin available to us.
         """
         logger.info('Resetting fund')
 

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -90,7 +90,11 @@ class Fund:
                 )
             # Wait until our next time to run, accounting for the time that
             # this step took to run
-            sleep(period - ((time() - start_time) % period))
+            step_time = time() - start_time
+            logger.debug(f'Trading step took {step_time} seconds')
+            sleep_time = period - (step_time % period)
+            logger.debug(f'Sleeping {sleep_time} seconds until next step')
+            sleep(sleep_time)
 
     def begin_backtest(
         self,

--- a/moneybot/market/adapters/live.py
+++ b/moneybot/market/adapters/live.py
@@ -32,7 +32,7 @@ class LiveMarketAdapter(MarketAdapter):
     def get_balances(self) -> Dict[str, float]:
         bals = self.polo.return_complete_balances()
         all_balances = {}
-        for coin, bal, in bals.items():
+        for (coin, bal) in bals.items():
             avail = float(bal['available'])
             if avail > 0:
                 all_balances[coin] = avail

--- a/moneybot/market/state.py
+++ b/moneybot/market/state.py
@@ -75,6 +75,9 @@ class MarketState:
         markets = self._available_markets()  # All of these start with fiat
         return frozenset(self._coin_names(m)[1] for m in markets) | {self.fiat}
 
+    def available_coins_not_held(self) -> FrozenSet[str]:
+        return self.available_coins() - self._held_coins()
+
     def held_coins_with_chart_data(self) -> FrozenSet[str]:
         return self._held_coins() & self.available_coins()
 

--- a/moneybot/strategy.py
+++ b/moneybot/strategy.py
@@ -164,7 +164,7 @@ class Strategy(metaclass=ABCMeta):
         """
         total_value = market_state.estimate_total_value()
         target_coins = self._possible_investments(market_state)
-        ideal_fiat_value_per_coin = total_value / len(target_coins) + 1.0  # Including fiat
+        ideal_fiat_value_per_coin = total_value / (len(target_coins) + 1.0)  # Including fiat
 
         est_values = market_state.estimate_values()
 

--- a/moneybot/strategy.py
+++ b/moneybot/strategy.py
@@ -104,6 +104,7 @@ class Strategy(metaclass=ABCMeta):
     def __init__(self, fiat: str, trade_interval: int) -> None:
         self.fiat = fiat
         self.trade_interval = trade_interval  # Time between trades, in seconds
+        self.has_proposed_initial_trades = False
 
     @abstractmethod
     def propose_trades(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 import pytest
 import staticconf
 import yaml
@@ -19,3 +21,4 @@ def config():
         yaml.load(TEST_CONFIG),
         namespace=moneybot.CONFIG_NS,
     )
+    logging.basicConfig(level=logging.INFO)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,10 +50,10 @@ def expected_results():
     ]
 
 
-def test_strategies(expected_results):
-    '''
-    Strategies should produce their expected values
-    '''
+def test_strategies_btc_only(expected_results):
+    """Strategies should produce their expected values when starting with a
+    fiat-only portfolio.
+    """
     # The start and end of our test period
     start = '2017-05-01'
     end = '2017-06-01'
@@ -69,13 +69,36 @@ def test_strategies(expected_results):
         )
         fund = Fund(strategy, adapter)
         res = list(fund.begin_backtest(start, end))
-        # print(res)
+        assert res == expected['values']
+
+
+@pytest.mark.skip
+def test_strategies_mixed_start(expected_results):
+    """Strategies should produce their expected values when starting with a
+    mixed portfolio.
+
+    TODO: Enable this once we agree on what the values should be.
+    """
+    # The start and end of our test period
+    start = '2017-05-01'
+    end = '2017-06-01'
+    fiat = config.read_string('trading.fiat')
+    interval = config.read_int('trading.interval')
+
+    for expected in expected_results:
+        strategy = expected['strategy'](fiat, interval)
+        adapter = BacktestMarketAdapter(
+            MarketHistoryMock(),
+            {'BTC': 1.0, 'ETH': 12.3},
+            fiat,
+        )
+        fund = Fund(strategy, adapter)
+        res = list(fund.begin_backtest(start, end))
         assert res == expected['values']
 
 
 def test_all_results_diff(expected_results):
-    '''
-    No two results should be equal.
-    '''
+    """No two results should be equal.
+    """
     for i, expected in enumerate(expected_results[:-1]):
         assert expected != expected_results[i + 1]


### PR DESCRIPTION
This addresses (at least partially) #45; now the initial proposed trades will result in a balanced portfolio regardless of your starting balances/asset distribution.

All our example strategies currently use `market_state.only_holding(self.fiat)` as the signal for whether to make initial trades or not. This doesn't work anymore, so here I propose that we just always make initial trades when moneybot starts up. This isn't a great solution – feel free to suggest improvements.