### PR TITLE
Refactoring `force_rebalance`

### DIFF
--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -31,10 +31,11 @@ def main(args):
 
     fund = Fund(strategy, adapter)
 
-    if args.force_rebalance is True:
-        confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
-        if confirm.strip().lower() == 'y':
-            fund.rebalance()
+    # TODO
+    # if args.force_rebalance is True:
+    #     confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
+    #     if confirm.strip().lower() == 'y':
+    #         fund.rebalance()
     fund.run_live()
 
 

--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -34,7 +34,7 @@ def main(args):
     if args.force_rebalance is True:
         confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
         if confirm.strip().lower() == 'y':
-            fund.force_rebalance = True
+            fund.force_rebalance_next_step = True
     fund.run_live()
 
 

--- a/examples/live_trading.py
+++ b/examples/live_trading.py
@@ -31,11 +31,10 @@ def main(args):
 
     fund = Fund(strategy, adapter)
 
-    # TODO
-    # if args.force_rebalance is True:
-    #     confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
-    #     if confirm.strip().lower() == 'y':
-    #         fund.rebalance()
+    if args.force_rebalance is True:
+        confirm = input('Are you sure you want to rebalance your fund? [y/N] ')
+        if confirm.strip().lower() == 'y':
+            fund.force_rebalance = True
     fund.run_live()
 
 

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -41,6 +41,10 @@ class Fund:
         self.market_adapter = adapter
         # MarketHistory stores historical market data
         self.market_history = adapter.market_history
+        # A boolean the caller can set
+        # to force a rebalance on the next trading step
+        # (after that rebalance, this will be reset to `False`)
+        self.force_rebalance = False
 
     def step(
         self,
@@ -91,7 +95,18 @@ class Fund:
                 self.market_history.scrape_latest()
                 # Now the fund can step()
                 logger.info(f'Fund::step({cur_dt})')
-                usd_val = self.step(cur_dt)
+                # The caller can "queue up" a `force_rebalance`
+                # for the next trading step.
+                # If that's been done,
+                if self.force_rebalance = True:
+                    # We can pass it down to `self.step()`
+                    usd_val = self.step(cur_dt, force_rebalance=True)
+                    # And disable it for next time.
+                    self.force_rebalance = False
+                # Otherwise,
+                else:
+                    # Just perform a regular step
+                    usd_val = self.step(cur_dt)
                 # After its step, we have got the USD value.
                 logger.info(f'Est. USD value: {usd_val}')
             except PoloniexServerError:

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -42,23 +42,6 @@ class Fund:
         # MarketHistory stores historical market data
         self.market_history = adapter.market_history
 
-    # def rebalance(self) -> float:
-    #     """Reset the fund to a value-balanced state, i.e. we hold an equal
-    #     value (measured in fiat) of every coin available to us.
-    #     """
-    #     logger.info('Resetting fund')
-
-    #     now = datetime.now()
-    #     self.market_history.scrape_latest()
-    #     market_state = self.market_adapter.get_market_state(now)
-    #     proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
-    #     if proposed_trades:
-    #         self.market_adapter.filter_and_execute(proposed_trades)
-
-    #     usd_val = self.market_adapter.market_state.estimate_total_value_usd()
-    #     logger.info(f'Est. USD value: {usd_val}')
-    #     return usd_val
-
     def step(
         self,
         time: datetime,
@@ -74,7 +57,7 @@ class Fund:
         copied_market_state = deepcopy(market_state)
         # Optionally, we can we rebalance the whole fund manually
         if force_rebalance:
-            print('FORCING A REBALANCE!!!!!!!!!!!!!!!')
+            # TODO This doesn't work right now
             proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
         else:
             # Otherwise, the fund will decide if it's time to rebalance

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -61,8 +61,7 @@ class Fund:
         copied_market_state = deepcopy(market_state)
         # Optionally, we can we rebalance the whole fund manually
         if force_rebalance:
-            # TODO This doesn't work right now
-            proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
+            proposed_trades = self.strategy.propose_trades_for_total_rebalancing(copied_market_state)
         else:
             # Otherwise, the fund will decide if it's time to rebalance
             # using its method `propose trades`. If you're writing a
@@ -98,15 +97,11 @@ class Fund:
                 # The caller can "queue up" a force rebalance
                 # for the next trading step.
                 # If that's been done,
-                if self.force_rebalance_next_step:
-                    # We can pass it down to `self.step()`
-                    usd_val = self.step(cur_dt, force_rebalance=True)
-                    # And disable it for next time.
-                    self.force_rebalance_next_step = False
-                # Otherwise,
-                else:
-                    # Just perform a regular step
-                    usd_val = self.step(cur_dt)
+                # We can pass it down to `self.step()`
+                usd_val = self.step(cur_dt, force_rebalance=self.force_rebalance_next_step)
+                # In either case,
+                # we disable this rebalance for next time
+                self.force_rebalance_next_step = False
                 # After its step, we have got the USD value.
                 logger.info(f'Est. USD value: {usd_val}')
             except PoloniexServerError:

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -62,7 +62,7 @@ class Fund:
     def step(
         self,
         time: datetime,
-        force_rebalance: bool = False
+        force_rebalance: bool = False,
     ) -> float:
         # We make a copy of our MarketAdapter's market_state
         # This way, we can pass the copy to Strategy.propose_trades()
@@ -74,6 +74,7 @@ class Fund:
         copied_market_state = deepcopy(market_state)
         # Optionally, we can we rebalance the whole fund manually
         if force_rebalance:
+            print('FORCING A REBALANCE!!!!!!!!!!!!!!!')
             proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
         else:
             # Otherwise, the fund will decide if it's time to rebalance

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -98,7 +98,7 @@ class Fund:
                 # The caller can "queue up" a force rebalance
                 # for the next trading step.
                 # If that's been done,
-                if self.force_rebalance_next_step = True:
+                if self.force_rebalance_next_step:
                     # We can pass it down to `self.step()`
                     usd_val = self.step(cur_dt, force_rebalance=True)
                     # And disable it for next time.

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -44,7 +44,7 @@ class Fund:
         # A boolean the caller can set
         # to force a rebalance on the next trading step
         # (after that rebalance, this will be reset to `False`)
-        self.force_rebalance = False
+        self.force_rebalance_next_step = False
 
     def step(
         self,
@@ -95,14 +95,14 @@ class Fund:
                 self.market_history.scrape_latest()
                 # Now the fund can step()
                 logger.info(f'Fund::step({cur_dt})')
-                # The caller can "queue up" a `force_rebalance`
+                # The caller can "queue up" a force rebalance
                 # for the next trading step.
                 # If that's been done,
-                if self.force_rebalance = True:
+                if self.force_rebalance_next_step = True:
                     # We can pass it down to `self.step()`
                     usd_val = self.step(cur_dt, force_rebalance=True)
                     # And disable it for next time.
-                    self.force_rebalance = False
+                    self.force_rebalance_next_step = False
                 # Otherwise,
                 else:
                     # Just perform a regular step

--- a/moneybot/fund.py
+++ b/moneybot/fund.py
@@ -42,24 +42,28 @@ class Fund:
         # MarketHistory stores historical market data
         self.market_history = adapter.market_history
 
-    def rebalance(self) -> float:
-        """Reset the fund to a value-balanced state, i.e. we hold an equal
-        value (measured in fiat) of every coin available to us.
-        """
-        logger.info('Resetting fund')
+    # def rebalance(self) -> float:
+    #     """Reset the fund to a value-balanced state, i.e. we hold an equal
+    #     value (measured in fiat) of every coin available to us.
+    #     """
+    #     logger.info('Resetting fund')
 
-        now = datetime.now()
-        self.market_history.scrape_latest()
-        market_state = self.market_adapter.get_market_state(now)
-        proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
-        if proposed_trades:
-            self.market_adapter.filter_and_execute(proposed_trades)
+    #     now = datetime.now()
+    #     self.market_history.scrape_latest()
+    #     market_state = self.market_adapter.get_market_state(now)
+    #     proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
+    #     if proposed_trades:
+    #         self.market_adapter.filter_and_execute(proposed_trades)
 
-        usd_val = self.market_adapter.market_state.estimate_total_value_usd()
-        logger.info(f'Est. USD value: {usd_val}')
-        return usd_val
+    #     usd_val = self.market_adapter.market_state.estimate_total_value_usd()
+    #     logger.info(f'Est. USD value: {usd_val}')
+    #     return usd_val
 
-    def step(self, time: datetime) -> float:
+    def step(
+        self,
+        time: datetime,
+        force_rebalance: bool = False
+    ) -> float:
         # We make a copy of our MarketAdapter's market_state
         # This way, we can pass the copy to Strategy.propose_trades()
         # without having to worry about the strategy mutating the market_state
@@ -68,9 +72,14 @@ class Fund:
         # except through ProposedTrades.
         market_state = self.market_adapter.get_market_state(time)
         copied_market_state = deepcopy(market_state)
-        # print('market_state.balances', market_state.balances)
-        # Now, propose trades. If you're writing a strategy, you will implement this method.
-        proposed_trades = self.strategy.propose_trades(copied_market_state, self.market_history)
+        # Optionally, we can we rebalance the whole fund manually
+        if force_rebalance:
+            proposed_trades = self.strategy.propose_trades_for_total_rebalancing(market_state)
+        else:
+            # Otherwise, the fund will decide if it's time to rebalance
+            # using its method `propose trades`. If you're writing a
+            # strategy, you will implement this method!
+            proposed_trades = self.strategy.propose_trades(copied_market_state, self.market_history)
         # If the strategy proposed any trades,
         if proposed_trades:
             # the MarketAdapter will execute them.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -61,8 +61,10 @@ def test_strategy_force_rebalacne():
     # but force a rebalance for it,
     # the following value should *not* be what we expect
     new_value = fund.step(Timestamp('2017-06-01'), force_rebalance=True)
-    print(new_value)
+    # Should not equal the next value we would have seen before
     assert new_value != 3801.01
+    # Instead, equals some new value post-rebalance
+    assert new_value == 3851.61
 
 
 '''

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,7 +22,7 @@ def test_strategy_step():
 
     initial_balances = {fiat: 1.0}
 
-    strategy = BuyHoldStrategy(fiat, 86400)
+    strategy = BuffedCoinStrategy(fiat, 86400)
     adapter = BacktestMarketAdapter(
         MarketHistoryMock(),
         initial_balances,
@@ -34,18 +34,18 @@ def test_strategy_step():
     assert new_value == 1318.21
 
 
-@pytest.mark.skip(reason="Strategy::propose_trades_for_total_rebalancing currently proposes impossible trades")
 def test_strategy_force_rebalacne():
     """Strategies can force a rebalance
     by passing `force_rebalance=True`
     into `Fund::step`
     """
     fiat = 'BTC'
-    today = Timestamp('2017-05-01')
+    start = '2017-05-01'
+    end = '2017-05-30'
 
     initial_balances = {fiat: 1.0}
 
-    strategy = BuyHoldStrategy(fiat, 86400)
+    strategy = BuffedCoinStrategy(fiat, 86400)
     adapter = BacktestMarketAdapter(
         MarketHistoryMock(),
         initial_balances,
@@ -53,8 +53,16 @@ def test_strategy_force_rebalacne():
     )
     fund = Fund(strategy, adapter)
 
-    new_value = fund.step(today, force_rebalance=True)
-    assert new_value != 1318.21
+    # First we'll run a backtest, and see that the latest value is what we expect
+    results = list(fund.begin_backtest(start, end))
+    assert results[-1] == 3551.63
+
+    # Now, if we do one more step,
+    # but force a rebalance for it,
+    # the following value should *not* be what we expect
+    new_value = fund.step(Timestamp('2017-06-01'), force_rebalance=True)
+    print(new_value)
+    assert new_value != 3801.01
 
 
 '''

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,11 +1,64 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from pandas import Timestamp
+
 from moneybot.examples.strategies import BuffedCoinStrategy
 from moneybot.examples.strategies import BuyHoldStrategy
 from moneybot.fund import Fund
 from moneybot.testing import MarketHistoryMock
 from moneybot.market.adapters.backtest import BacktestMarketAdapter
+
+'''
+Fund method tests
+'''
+
+
+def test_strategy_step():
+    """Strategies can step forward.
+    """
+    fiat = 'BTC'
+    today = Timestamp('2017-05-02')
+
+    initial_balances = {fiat: 1.0}
+
+    strategy = BuyHoldStrategy(fiat, 86400)
+    adapter = BacktestMarketAdapter(
+        MarketHistoryMock(),
+        initial_balances,
+        fiat,
+    )
+    fund = Fund(strategy, adapter)
+
+    new_value = fund.step(today)
+    assert new_value == 1383.51
+
+
+def test_strategy_force_rebalacne():
+    """Strategies can force a rebalance
+    by passing `force_rebalance=True`
+    into `Fund::step`
+    """
+    fiat = 'BTC'
+    today = Timestamp('2017-05-02')
+
+    initial_balances = {fiat: 1.0}
+
+    strategy = BuyHoldStrategy(fiat, 86400)
+    adapter = BacktestMarketAdapter(
+        MarketHistoryMock(),
+        initial_balances,
+        fiat,
+    )
+    fund = Fund(strategy, adapter)
+
+    new_value = fund.step(today, force_rebalance=True)
+    assert new_value == 1383.51
+
+
+'''
+Integration tests
+'''
 
 
 @pytest.mark.parametrize('strategy_cls,expected', [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,7 +18,7 @@ def test_strategy_step():
     """Strategies can step forward.
     """
     fiat = 'BTC'
-    today = Timestamp('2017-05-02')
+    today = Timestamp('2017-05-01')
 
     initial_balances = {fiat: 1.0}
 
@@ -31,16 +31,17 @@ def test_strategy_step():
     fund = Fund(strategy, adapter)
 
     new_value = fund.step(today)
-    assert new_value == 1383.51
+    assert new_value == 1318.21
 
 
+@pytest.mark.skip(reason="Strategy::propose_trades_for_total_rebalancing currently proposes impossible trades")
 def test_strategy_force_rebalacne():
     """Strategies can force a rebalance
     by passing `force_rebalance=True`
     into `Fund::step`
     """
     fiat = 'BTC'
-    today = Timestamp('2017-05-02')
+    today = Timestamp('2017-05-01')
 
     initial_balances = {fiat: 1.0}
 
@@ -53,7 +54,7 @@ def test_strategy_force_rebalacne():
     fund = Fund(strategy, adapter)
 
     new_value = fund.step(today, force_rebalance=True)
-    assert new_value == 1383.51
+    assert new_value != 1318.21
 
 
 '''

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -61,9 +61,10 @@ def test_strategy_force_rebalacne():
     # but force a rebalance for it,
     # the following value should *not* be what we expect
     new_value = fund.step(Timestamp('2017-06-01'), force_rebalance=True)
-    # Should not equal the next value we would have seen before
-    assert new_value != 3801.01
-    # Instead, equals some new value post-rebalance
+    # If we had NOT rebalanced,
+    # The value here would have been
+    #   3801.01
+    # Instead, we should see some other value:
     assert new_value == 3851.61
 
 


### PR DESCRIPTION
This PR refactors out some repeated code from the `strategy.rebalance()` method, by making this functionality accessible via an optional call to `Strategy::step`.

In doing so, it slightly changes the way `examples/live_trading.py` uses the `--force-rebalance` flag.

We also add a couple tests:

1. A simple integration test for `Strategy::step`, checking that stepping through the first step of `BuyHoldStrategy` returns the expected first value.

2. An integration test for passing `skip_step=False` to `step`.  

(Yes, there are lots of commits there here - just view all changes for now, will squash on merge)